### PR TITLE
Azalee's talk title, and dinner details

### DIFF
--- a/pages/2017/program.rst
+++ b/pages/2017/program.rst
@@ -86,3 +86,5 @@ Friday
 -  **14:00** - Unconference
 -  **15:30** - Unconference Summary
 -  **16:00** - Adjourn
+
+Talk abstracts are available on the `Lorentz Center website <http://lorentzcenter.nl/lc/web/2017/896/extra.php3?wsid=896&venue=Oort>`_.

--- a/pages/2017/program.rst
+++ b/pages/2017/program.rst
@@ -47,13 +47,15 @@ Wednesday
 -  **09:50** - David Shupe - *'Python widgets for astronomy visualization'*
 -  **10:10** - Coffee
 -  **10:40** - Lucia Klarmann - *'Project based Python teaching: Lessons from the two-body problem and beyond'*
--  **11:00** - Code Review
+-  **11:00** - K. Azalee Bostroem - (Keynote) *'Code review: Building a community to talk about coding'*
 -  **11:45** - Lightning talks
 -  **12:30** - Lunch and organizing unconference sessions
 -  **14:00** - Unconference
 -  **16:00** - Coffee
 -  **16:30** - Plenary summary of unconferences and discussion
--  **17:00** - Bus to Dinner
+-  **17:00** - Bus to the dinner boat
+-  **17:30** - Boat tour with buffet dinner
+-  **21:30** - Bus back to Lorentz Center, train station, and hotel
 
 Thursday
 --------


### PR DESCRIPTION
Changed 'code review' on Wednesday to have Azalee's talk title (and note that it's a keynote talk). Also added dinner time details on Wednesday.