### PR TITLE
Add a page for the 2018 conference

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -51,8 +51,9 @@ GITHUB_COMMIT_SOURCE=False
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
         ("/", "Python in Astronomy"),
-        ("/2017/", "2017"),
-        ((("/2016/", "2016"),
+        ("/2018/", "2018"),
+        ((("/2017/", "2017"),
+          ("/2016/", "2016"),
           ("/2015/", "2015")), "Previous Conferences")
     ),
 }

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -29,7 +29,7 @@ Details
 
 The `Center for Computational Astrophysics <https://www.simonsfoundation.org/flatiron/center-for-computational-astrophysics/>`_
 is a research center committed to developing the research tools needed for modern astronomy.
-All participants at the conference will be expected to follow the `code of conduct </code-of-conduct>`_
+All participants at the conference will be expected to follow the `code of conduct </code-of-conduct>`_.
 
 Program
 #######

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -66,36 +66,4 @@ The organising committee consists of: Matt Craig (chair), Azalee Bostroem, Danie
 
 To contact the SOC, send an email to python.in.astronomy.soc $AT$ gmail.com.
 
-Sponsors
-########
 
-Python in Astronomy 2017 is kindly sponsored by:
-
-|lorentz logo|  |NumFOCUS logo|
-
-|PSF logo|  |astron logo|
-
-|eSciences logo| |Aperio logo|
-
-.. |lorentz logo| image:: /images/logolorentznieuw.png
-   :target: http://www.lorentzcenter.nl
-   :width: 45%
-
-.. |astron logo| image:: http://astron.nl/sites/astron.nl/files/logo.gif
-   :target: http://astron.nl/
-   :width: 45%
-
-.. |numfocus logo| image:: https://numfocus.wpengine.com/wp-content/uploads/2017/03/1457562110.png
-   :target: http://www.numfocus.org/
-   :width: 45%
-
-.. |PSF logo| image:: /images/PSF_logo_noalpha.png
-   :width: 45%
-
-.. |Aperio logo| image:: https://aperiosoftware.com/images/logo.svg
-   :target: https://aperiosoftware.com/
-   :width: 45%
-
-.. |eSciences logo| image:: /images/eScience_Logo_HR_noalpha.png
-   :target: http://escience.washington.edu/
-   :width: 45%

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -18,7 +18,7 @@ Computational Astrophysics at the Flatiron Institute in New York from
 This conference aims to bring a wide variety of people who use, develop or teach
 people about Python packages in the context of all forms of Astronomy. The
 conference will include presentations, tutorials, unconference sessions, and
-sprints. As well as building the community around astronomical uses of Python,
+sprints. As well as enhancing the community around astronomical uses of Python,
 the conference aims to improve collaboration and interoperability between
 Python packages, and share knowledge on Python packages and techniques. It will
 also provide training and educational materials for users and developers of

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -1,11 +1,11 @@
-Python in Astronomy 2017
-========================
+Python in Astronomy 2018
+=========================
 
 30 April - 4 May 2018
----------------------
+-----------------------
 
 Center for Computational Astrophysics, Flatiron Institute, New York
--------------------------------------------------------------------
+----------------------------------------------------------------------
 
 .. image:: /images/pyastro_logo_150px.png
    :align: center

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -1,0 +1,105 @@
+Python in Astronomy 2017
+========================
+
+8 - 12 May 2017
+---------------
+
+Lorentz Center, Leiden
+----------------------
+
+.. image:: /images/pyastro_logo_150px.png
+   :align: center
+   :width: 150px
+
+The third edition of the Python in Astronomy Conference will be held at the
+Lorentz Center from **8 - 12th May 2017**.
+
+This conference aims to bring a wide variety of people who use, develop or teach
+people about Python packages in the context of all forms of Astronomy. The
+conference will include presentations, tutorials, unconference sessions, and
+sprints. As well as building the community around astronomical uses of Python,
+the conference aims to improve collaboration and interoperability between
+Python packages, and share knowledge on Python packages and techniques. It will
+also provide training and educational materials for users and developers of
+Python astronomy packages.
+
+Details
+#######
+
+The `Lorentz Center <http://www.lorentzcenter.nl>`_ is an international center for scientific workshops, based on
+the philosophy that science thrives on interaction between creative researchers.
+Python in Astronomy 2017 will be hosted in the "`Oort venue
+<http://www.lorentzcenter.nl/facilities.php>`_", which has a maximum
+capacity of 55 people. All participants at the conference will
+be expected to follow the `code of conduct </code-of-conduct>`_.
+
+Program
+#######
+
+The program for the conference can be found `here <./program>`__.
+The talk abstracts can be found `here <http://lorentzcenter.nl/lc/web/2017/896/extra.php3?wsid=896&venue=Oort>`_.
+
+Our live stream and twitter feeds can be found on the `live <./live>`__ page, and additional materials are on the `Google Drive proceedings page <https://drive.google.com/drive/folders/0B3Gl3X9iCMeoQkpkUlFvQ3NVdnM?usp=sharing>`_.
+
+Social Media
+############
+
+The hashtag for this workshop is `#pyastro17 <https://twitter.com/hashtag/pyastro17>`_,
+and the main twitter account is `@pyastro17 <https://twitter.com/pyastro17>`_.
+Feel free to use the hashtag before, during, and after the workshop to connect with other participants and the wider
+community.
+Remember, when interacting with people either in person or online, you
+are required to follow the `code of conduct </code-of-conduct>`_.
+
+Livestream and Live Chat
+########################
+
+To accommodate remote participation, we will livestream the morning plenary talks and some of the afternoon tutorials on YouTube.
+The link will be posted here on Monday morning (May 8th) once it's set up.
+The local timezone of the conference is CEST (UTC+2).
+The videos will then be saved and viewable on YouTube afterwards.
+
+We encourage all participants (including remote participants) to join our `chat room via Matrix <https://riot.im/app/#/room/#pyastro:matrix.org>`_ to allow people who couldn't attend to follow along, and to interact in real-time with other participants!
+This chat room will also be the most direct way for anyone remotely following along to ask questions during the livestream.
+
+Organising Committee
+####################
+
+The organising committee consists of: Stuart Mumford (chair), Matt Craig, Kelle Cruz,
+Daniela Huppenkothen, Abigail Stevens, and Erik Tollerud.
+
+To contact the SOC, send an email to python.in.astronomy.soc $AT$ gmail.com.
+
+Sponsors
+########
+
+Python in Astronomy 2017 is kindly sponsored by:
+
+|lorentz logo|  |NumFOCUS logo|
+
+|PSF logo|  |astron logo|
+
+|eSciences logo| |Aperio logo|
+
+.. |lorentz logo| image:: /images/logolorentznieuw.png
+   :target: http://www.lorentzcenter.nl
+   :width: 45%
+
+.. |astron logo| image:: http://astron.nl/sites/astron.nl/files/logo.gif
+   :target: http://astron.nl/
+   :width: 45%
+
+.. |numfocus logo| image:: https://numfocus.wpengine.com/wp-content/uploads/2017/03/1457562110.png
+   :target: http://www.numfocus.org/
+   :width: 45%
+
+.. |PSF logo| image:: /images/PSF_logo_noalpha.png
+   :width: 45%
+
+.. |Aperio logo| image:: https://aperiosoftware.com/images/logo.svg
+   :target: https://aperiosoftware.com/
+   :width: 45%
+
+.. |eSciences logo| image:: /images/eScience_Logo_HR_noalpha.png
+   :target: http://escience.washington.edu/
+   :width: 45%

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -1,18 +1,19 @@
 Python in Astronomy 2017
 ========================
 
-8 - 12 May 2017
----------------
+30 April - 4 May 2018
+---------------------
 
-Lorentz Center, Leiden
-----------------------
+Center for Computational Astrophysics, Flatiron Institute, New York
+-------------------------------------------------------------------
 
 .. image:: /images/pyastro_logo_150px.png
    :align: center
    :width: 150px
 
-The third edition of the Python in Astronomy Conference will be held at the
-Lorentz Center from **8 - 12th May 2017**.
+The fourth Python in Astronomy Conference will be held at the Center for
+Computational Astrophysics at the Flatiron Institute in New York from
+**30th April - 4th May 2018**.
 
 This conference aims to bring a wide variety of people who use, develop or teach
 people about Python packages in the context of all forms of Astronomy. The

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -45,8 +45,8 @@ Our live stream and twitter feeds can be found on the `live <./live>`__ page, an
 Social Media
 ############
 
-The hashtag for this workshop is `#pyastro17 <https://twitter.com/hashtag/pyastro17>`_,
-and the main twitter account is `@pyastro17 <https://twitter.com/pyastro17>`_.
+The hashtag for this workshop is `#pyastro18 <https://twitter.com/hashtag/pyastro18>`_,
+and the main twitter account is `@pyastro18 <https://twitter.com/pyastro18>`_.
 Feel free to use the hashtag before, during, and after the workshop to connect with other participants and the wider
 community.
 Remember, when interacting with people either in person or online, you
@@ -66,8 +66,7 @@ This chat room will also be the most direct way for anyone remotely following al
 Organising Committee
 ####################
 
-The organising committee consists of: Stuart Mumford (chair), Matt Craig, Kelle Cruz,
-Daniela Huppenkothen, Abigail Stevens, and Erik Tollerud.
+The organising committee consists of: Matt Craig (chair), Azalee Bostroem, Daniela Huppenkothen, Andrew Leonard, Duncan Macleod, Brigitta Sipocz and Erik Tollerud.
 
 To contact the SOC, send an email to python.in.astronomy.soc $AT$ gmail.com.
 

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -34,10 +34,9 @@ All participants at the conference will be expected to follow the `code of condu
 Program
 #######
 
-The program for the conference can be found `here <./program>`__.
-The talk abstracts can be found `here <http://lorentzcenter.nl/lc/web/2017/896/extra.php3?wsid=896&venue=Oort>`_.
 
-Our live stream and twitter feeds can be found on the `live <./live>`__ page, and additional materials are on the `Google Drive proceedings page <https://drive.google.com/drive/folders/0B3Gl3X9iCMeoQkpkUlFvQ3NVdnM?usp=sharing>`_.
+When they are finalised, the programme and talk abstracts for the conference will be available here.
+There will also be links to the live stream, twitter feed and Google Drive proceedings page containing additional materials.
 
 Social Media
 ############

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -56,8 +56,8 @@ Livestream and Live Chat
 ########################
 
 To accommodate remote participation, we will livestream the morning plenary talks and some of the afternoon tutorials on YouTube.
-The link will be posted here on Monday morning (May 8th) once it's set up.
-The local timezone of the conference is CEST (UTC+2).
+The link will be posted here on Monday morning (April 30th) once it's set up.
+The local timezone of the conference is EDT (UTC-4).
 The videos will then be saved and viewable on YouTube afterwards.
 
 We encourage all participants (including remote participants) to join our `chat room via Matrix <https://riot.im/app/#/room/#pyastro:matrix.org>`_ to allow people who couldn't attend to follow along, and to interact in real-time with other participants!

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -27,12 +27,9 @@ Python astronomy packages.
 Details
 #######
 
-The `Lorentz Center <http://www.lorentzcenter.nl>`_ is an international center for scientific workshops, based on
-the philosophy that science thrives on interaction between creative researchers.
-Python in Astronomy 2017 will be hosted in the "`Oort venue
-<http://www.lorentzcenter.nl/facilities.php>`_", which has a maximum
-capacity of 55 people. All participants at the conference will
-be expected to follow the `code of conduct </code-of-conduct>`_.
+The `Center for Computational Astrophysics <https://www.simonsfoundation.org/flatiron/center-for-computational-astrophysics/>`_
+is a research center committed to developing the research tools needed for modern astronomy.
+All participants at the conference will be expected to follow the `code of conduct </code-of-conduct>`_
 
 Program
 #######

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -10,6 +10,13 @@ Python in Astronomy is a conference series focusing on the use,
 development, and community surrounding Python packages for all types of
 Astronomy.
 
+`2018 </2018>`__
+----------------
+
+The next conference will be held at the `Center for Computational Astrophysics
+<https://www.simonsfoundation.org/flatiron/center-for-computational-astrophysics/>`__
+in New York on the 30th April - 4th May. More details can be found `here </2018>`__
+
 `2017 </2017>`__
 ----------------
 

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -15,7 +15,7 @@ Astronomy.
 
 The next conference will be held at the `Center for Computational Astrophysics
 <https://www.simonsfoundation.org/flatiron/center-for-computational-astrophysics/>`__
-in New York on the 30th April - 4th May. More details can be found `here </2018>`__
+in New York on the 30th April - 4th May. More details can be found `here </2018>`__.
 
 `2017 </2017>`__
 ----------------


### PR DESCRIPTION
This is mostly copied and pasted from last year's page, with a few of the obvious necessary changes. Still need to update the sponsors section, and add links for the live streaming page, unproceedings folder, programme and abstracts when all those things exist.