### PR TITLE
Fix page titles

### DIFF
--- a/pages/2015/index.rst
+++ b/pages/2015/index.rst
@@ -1,6 +1,4 @@
-
-Python in Astronomy
-===================
+.. title: Python in Astronomy
 
 
 20-24 April 2015

--- a/pages/2016/index.rst
+++ b/pages/2016/index.rst
@@ -1,5 +1,4 @@
-Python in Astronomy 2016
-========================
+.. title: Python in Astronomy 2016
 
 21-25 March 2016
 ----------------

--- a/pages/2017/index.rst
+++ b/pages/2017/index.rst
@@ -1,5 +1,4 @@
-Python in Astronomy 2017
-========================
+.. title: Python in Astronomy 2017
 
 8 - 12 May 2017
 ---------------

--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -1,5 +1,4 @@
-Python in Astronomy 2018
-=========================
+.. title: Python in Astronomy 2018
 
 30 April - 4 May 2018
 -----------------------

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -1,5 +1,4 @@
-Python in Astronomy
-===================
+.. title: Python in Astronomy
 
 .. image:: /images/pyastro_logo_150px.png
    :align: center


### PR DESCRIPTION
Apparently some nikola update means they are no longer generated from the first rST heading...so now they are a comment at the top of each file.