### PR TITLE
Remove osx build from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 
 os:
   - linux
-  - osx
 
 sudo: false
 


### PR DESCRIPTION
@astrofrog -- any objection to this? The travis osx is really backed up and it isn't clear to me what testing on osx adds (deploys are done from linux).