### PR TITLE
Pad sponsor logos

### DIFF
--- a/pages/2018/index.rst
+++ b/pages/2018/index.rst
@@ -83,14 +83,16 @@ Center for Computational Astrophysics at the Flatiron Institute
 ##################################################################
 |flatiron logo|
 
-
 .. |flatiron logo| image:: /images/flatiron_logo_white.png
+   :class: sponsor-logo
    :target: https://www.simonsfoundation.org/flatiron/center-for-computational-astrophysics/
    :width: 70%
 
 .. |numfocus logo| image:: https://numfocus.wpengine.com/wp-content/uploads/2017/03/1457562110.png
+   :class: sponsor-logo
    :target: http://www.numfocus.org/
    :width: 45%
 
 .. |PSF logo| image:: /images/PSF_logo_noalpha.png
+   :class: sponsor-logo
    :width: 45%

--- a/themes/pyastro/assets/css/theme.css
+++ b/themes/pyastro/assets/css/theme.css
@@ -173,7 +173,7 @@ div.row {
 
 .sponsor-logo {
     display: block;
-    margin: 30px auto 30px auto;
+    margin: 120px auto 120px auto;
 }
 
 /* Copied */

--- a/themes/pyastro/assets/css/theme.css
+++ b/themes/pyastro/assets/css/theme.css
@@ -171,9 +171,10 @@ div.row {
 
 /* Add a bit of padding around sponsor logos */
 
-/* img { */
-/*     margin: 50px; */
-/* } */
+.sponsor-logo {
+    display: block;
+    margin: 30px auto 30px auto;
+}
 
 /* Copied */
 


### PR DESCRIPTION
Add a new sponsor-logo class to the CSS theme and use it for the logos. Did it this way because then it only affects those images and not any others or the ones from previous years.

Does require a `:class: sponsor-logo` when defining the image.